### PR TITLE
Increase coverage of Protobuf TextMate grammar

### DIFF
--- a/syntaxes/proto.tmLanguage.json
+++ b/syntaxes/proto.tmLanguage.json
@@ -149,6 +149,9 @@
           "include": "#comment"
         },
         {
+          "include": "#option"
+        },
+        {
           "include": "#field-group"
         },
         {

--- a/syntaxes/proto.tmLanguage.json
+++ b/syntaxes/proto.tmLanguage.json
@@ -15,6 +15,9 @@
       "include": "#message"
     },
     {
+      "include": "#field-extends"
+    },
+    {
       "include": "#option"
     },
     {
@@ -150,6 +153,9 @@
         },
         {
           "include": "#field-statement"
+        },
+        {
+          "include": "#field-extends"
         },
         {
           "include": "#field-oneof"
@@ -452,6 +458,32 @@
           "name": "constant.numeric.proto"
         },
         "6": {
+          "name": "punctuation.definition.extend.begin.proto"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.extend.end.proto"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#field-statement"
+        }
+      ]
+    },
+    "field-extends": {
+      "name": "statement.field-extends.proto",
+      "begin": "\\b(extend)\\s+([a-zA-Z0-9\\-\\_]+)\\s*(\\{)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.extend.proto"
+        },
+        "2": {
+          "name": "entity.name.type.extend.proto"
+        },
+        "3": {
           "name": "punctuation.definition.extend.begin.proto"
         }
       },

--- a/syntaxes/proto.tmLanguage.json
+++ b/syntaxes/proto.tmLanguage.json
@@ -6,6 +6,9 @@
       "include": "#syntax"
     },
     {
+      "include": "#import"
+    },
+    {
       "include": "#package"
     },   
     {
@@ -47,7 +50,25 @@
       ]
     },
     "import": {
-
+      "name": "meta.import.proto",
+      "begin": "\\b(import)\\s*",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.import.proto"
+        }
+      },
+      "end": "\\;",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.terminator.proto"
+        }
+      },
+      "contentName": "meta.import.value.proto",
+      "patterns": [
+        {
+          "include": "#qstring-double"
+        }
+      ]
     },
     "package": {
       "name": "meta.package.proto",
@@ -287,7 +308,7 @@
     },
     "field-statement": {
       "name": "statement.field.proto",
-      "begin": "\\b(required|optional|repeated)?\\s*(?:(double|string|(?:(?:(?:(?:u|s)?int)|s?fixed)(?:32|64))|bool|bytes)|([a-zA-Z0-9\\-\\_]+))\\s+([a-zA-Z0-9\\-\\_]+)\\s*(=)\\s*([0-9]+)\\s*",
+      "begin": "\\b(required|optional|repeated)?\\s*(?:(double|string|(?:(?:(?:(?:u|s)?int)|s?fixed)(?:32|64))|bool|bytes)|([a-zA-Z0-9\\-\\_\\.]+))\\s+([a-zA-Z0-9\\-\\_]+)\\s*(=)\\s*([0-9]+)\\s*",
       "beginCaptures": {
         "1": {
           "name": "keyword.field.type.proto"

--- a/syntaxes/proto.tmLanguage.json
+++ b/syntaxes/proto.tmLanguage.json
@@ -21,6 +21,9 @@
       "include": "#option"
     },
     {
+      "include": "#service"
+    },
+    {
       "include": "#enum"
     },
     {
@@ -239,7 +242,33 @@
       ]
     },
     "service": {
-
+      "name": "statement.service.proto",
+      "begin": "\\b(service)\\b\\s*([a-zA-Z0-9\\-\\_]+)\\s*(\\{)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.service.proto"
+        },
+        "2": {
+          "name": "entity.name.type.service.proto"
+        },
+        "3": {
+          "name": "punctuation.definition.service.begin.proto"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.service.end.proto"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#rpc-method"
+        }
+      ]
     },
     "empty": {
 
@@ -530,6 +559,39 @@
           "match": "max"
         }
       ]
+    },
+    "rpc-method": {
+      "name": "statement.rpc-method.proto",
+      "match": "\\b(rpc)\\s+([0-9a-zA-Z\\-\\_]+)\\s*(\\()\\s*([a-zA-Z0-9\\-\\_\\.]+)\\s*(\\))\\s*(returns)\\s*(\\()\\s*([a-zA-Z0-9\\-\\_\\.]+)\\s*(\\))\\s*(\\;)",
+      "captures": {
+        "1": {
+          "name": "keyword.rpc.proto"
+        },
+        "2": {
+          "name": "entity.name.function.rpc.proto"
+        },
+        "3": {
+          "name": "punctuation.definition.parameters.begin.proto"
+        },
+        "4": {
+          "name": "entity.name.type.request.proto"
+        },
+        "5": {
+          "name": "punctuation.definition.parameters.end.proto"
+        },
+        "6": {
+          "name": "keyword.returns.proto"
+        },
+        "7": {
+          "name": "punctuation.definition.parameters.begin.proto"
+        },
+        "8": {
+          "name": "entity.name.type.response.proto"
+        },
+        "9": {
+          "name": "punctuation.definition.parameters.end.proto"
+        }
+      }
     }
   },
   "scopeName": "source.proto"

--- a/syntaxes/proto.tmLanguage.json
+++ b/syntaxes/proto.tmLanguage.json
@@ -467,6 +467,9 @@
       "patterns": [
         {
           "include": "#field-statement"
+        },
+        {
+          "include": "#comment"
         }
       ]
     },

--- a/syntaxes/proto.tmLanguage.json
+++ b/syntaxes/proto.tmLanguage.json
@@ -149,6 +149,9 @@
           "include": "#field-statement"
         },
         {
+          "include": "#field-oneof"
+        },
+        {
           "include": "#message"
         },
         {
@@ -397,6 +400,32 @@
         {
           "name": "entity.name.type.option.value.proto",
           "match": "\\b[a-zA-Z0-9\\-\\_]+\\b"
+        }
+      ]
+    },
+    "field-oneof": {
+      "name": "statement.field-oneof.proto",
+      "begin": "\\b(oneof)\\s+([a-zA-Z0-9\\-\\_]+)\\s*(\\{)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.oneof.proto"
+        },
+        "2": {
+          "name": "entity.name.type.oneof.proto"
+        },
+        "3": {
+          "name": "punctuation.definition.extend.begin.proto"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.extend.end.proto"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#field-statement"
         }
       ]
     },

--- a/syntaxes/proto.tmLanguage.json
+++ b/syntaxes/proto.tmLanguage.json
@@ -146,6 +146,9 @@
           "include": "#comment"
         },
         {
+          "include": "#field-group"
+        },
+        {
           "include": "#field-statement"
         },
         {
@@ -414,6 +417,41 @@
           "name": "entity.name.type.oneof.proto"
         },
         "3": {
+          "name": "punctuation.definition.extend.begin.proto"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.extend.end.proto"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#field-statement"
+        }
+      ]
+    },
+    "field-group": {
+      "name": "statement.field-group.proto",
+      "begin": "\\b(required|optional|repeated)?\\s*(group)\\s+([a-zA-Z0-9\\-\\_]+)\\s*(=)\\s*(\\d+)\\s*(\\{)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.group.type.proto"
+        },
+        "2": {
+          "name": "keyword.group.proto"
+        },
+        "3": {
+          "name": "entity.name.type.group.proto"
+        },
+        "4": {
+          "name": "punctuation.separator.key-value.proto"
+        },
+        "5": {
+          "name": "constant.numeric.proto"
+        },
+        "6": {
           "name": "punctuation.definition.extend.begin.proto"
         }
       },


### PR DESCRIPTION
- [Add support for import statements and imported MessageType](https://github.com/pbkit/vscode-pbkit/commit/72c3d5a500bae4138095b986afebd8c23331d766)
- [Add support for oneof field](https://github.com/pbkit/vscode-pbkit/commit/1cb61a753defe37c25ef4d11e2a9313480bea0c6)
	- [Add support for inline comment in enum statement](https://github.com/pbkit/vscode-pbkit/commit/f24751966c0e4ea7569c2774d786b2d0ae3d7a65)
- [Add support for group statement](https://github.com/pbkit/vscode-pbkit/commit/2f0d39f102005aab2c112d17fcf6a64f67a111aa)
- [Add support for extends statement](https://github.com/pbkit/vscode-pbkit/commit/2f18fffec990a0d3303c4803bce860cfe8df235d)
- [Add support for option statement in Message](https://github.com/pbkit/vscode-pbkit/commit/690ff421bd62c537b997f58452feb6c771ffef83)
- [Add support for rpc/service statement](https://github.com/pbkit/vscode-pbkit/commit/08a205c78f3fef38822acb7030f1cebf6cd17763)

resolves #8 
- multiline syntax highlighting will be resolved with implementing semantic token provider
- rpc/service highlighting added.