### PR TITLE
Enable kvpair at file level

### DIFF
--- a/syntaxes/prototext.tmLanguage.json
+++ b/syntaxes/prototext.tmLanguage.json
@@ -6,6 +6,9 @@
       "include": "#dictionary"
     },
     {
+      "include": "#kv-pair"
+    },
+    {
       "include": "#comment"
     }
   ],


### PR DESCRIPTION
This patch adds syntax highlighting of key-value pairs at file top-level.
This is allowed as per the [protobuf documentation](https://protobuf.dev/reference/protobuf/textformat-spec/#text-format-files).